### PR TITLE
rotate collapse icon 180deg when sidebar is collapsed

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   iconSrc: string;
   onClick: () => void;
   isCollapsed: boolean;
+  rotateIcon?: boolean;
 };
 
 export function MenuItemButton({
@@ -17,13 +18,18 @@ export function MenuItemButton({
   onClick,
   iconSrc,
   isCollapsed,
+  rotateIcon = false,
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
-        {!isCollapsed && text}{" "}
+        <img
+          className={classNames(styles.icon, rotateIcon && styles.rotateIcon)}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
+        {!isCollapsed && text}
       </Button>
     </li>
   );

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -30,3 +30,7 @@
   width: space.$s6;
   margin-right: space.$s3;
 }
+
+.icon.rotateIcon {
+  transform: rotate(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -91,6 +91,7 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}
+              rotateIcon={isSidebarCollapsed}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Modified the MenuItemButton component to accept an optional rotateIcon prop.
In the img element inside MenuItemButton, conditionally applied a CSS class that rotates the image. 
Modified menu-item-link.module.scss to define the rotation.
Modified SidebarNavigation component to pass the rotateIcon prop to MenuItemButton.