### PR TITLE
should always show large logo in header on mobile

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_BASE_URL=https://prolog-api.profy.dev

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -92,4 +92,17 @@ describe("Sidebar Navigation", () => {
       isNotInViewport("nav");
     });
   });
+
+  it("shows large logo in header when in mobile viewport size", () => {
+    // change viewport to mobile
+    cy.viewport("iphone-8");
+    // check that small logo is not visible in header
+    cy.get("header")
+      .find("img[src='/icons/logo-small.svg']")
+      .should("not.be.visible");
+    // check that large logo is visible in header
+    cy.get("header")
+      .find("img[src='/icons/logo-large.svg']")
+      .should("be.visible");
+  });
 });

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -48,6 +48,27 @@
   }
 }
 
+.logoLarge {
+  width: 7.375rem;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: none;
+    }
+  }
+}
+
+.logoSmall {
+  width: 1.4375rem;
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: block;
+    }
+  }
+}
+
 .logo {
   width: 7.375rem;
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -35,14 +35,22 @@ export function SidebarNavigation() {
       >
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
+
           <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src={"/icons/logo-large.svg"}
             alt="logo"
-            className={styles.logo}
+            className={classNames(
+              styles.logoLarge,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
+          />
+          <img
+            src={"/icons/logo-small.svg"}
+            alt="logo"
+            className={classNames(
+              styles.logoSmall,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
         "babel-loader": "^9.1.3",
-        "cypress": "^13.2.0",
+        "cypress": "^13.7.3",
         "eslint": "^8.47.0",
         "eslint-config-next": "^13.4.18",
         "eslint-config-prettier": "^9.0.0",
@@ -10612,21 +10612,20 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.0.tgz",
-      "integrity": "sha512-oh6U7h9w8wwHfzNDJQ6wVcAeXu31DlIYlNOBvfd6U4CcB8oe4akawQmH+QJVOMZlM42eBoCne015+svVqdwdRQ==",
+      "version": "13.7.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.3.tgz",
+      "integrity": "sha512-uoecY6FTCAuIEqLUYkTrxamDBjMHTYak/1O7jtgwboHiTnS1NaMOoR08KcTrbRZFCBvYOiS4tEkQRmsV+xcrag==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -10644,7 +10643,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -10667,15 +10666,6 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -32248,20 +32238,19 @@
       "dev": true
     },
     "cypress": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.5.0.tgz",
-      "integrity": "sha512-oh6U7h9w8wwHfzNDJQ6wVcAeXu31DlIYlNOBvfd6U4CcB8oe4akawQmH+QJVOMZlM42eBoCne015+svVqdwdRQ==",
+      "version": "13.7.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.3.tgz",
+      "integrity": "sha512-uoecY6FTCAuIEqLUYkTrxamDBjMHTYak/1O7jtgwboHiTnS1NaMOoR08KcTrbRZFCBvYOiS4tEkQRmsV+xcrag==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -32279,7 +32268,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -32298,15 +32287,6 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.18.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-          "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
     "babel-loader": "^9.1.3",
-    "cypress": "^13.2.0",
+    "cypress": "^13.7.3",
     "eslint": "^8.47.0",
     "eslint-config-next": "^13.4.18",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
- instead of encapsulating image source logic in a single tag, created two <img> tags, one for large logo and one for small
- in CSS, added logoLarge and logoSmall classes to handle logic for which logo should be displayed based on mobile/desktop viewport size and collapsed/uncollapsed states
- wrote cypress test
