### PR TITLE
using MenuItemLink for support link

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -36,7 +36,7 @@ describe("Sidebar Navigation", () => {
         .should(
           "have.attr",
           "href",
-          "mailto:support@prolog-app.com?subject=Support Request:",
+          "mailto:support@prolog-app.com?subject=Support Request: ",
         );
     });
 

--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -20,25 +20,6 @@ export function MenuItemButton({
   isCollapsed,
   rotateIcon = false,
 }: MenuItemProps) {
-  // Check if the button is the "support" button - if it is, render an anchor tag with a mailto link for support instead of a button
-  if (text === "Support") {
-    return (
-      <li className={classNames(styles.listItem, className)}>
-        <a
-          href="mailto:support@prolog-app.com?subject=Support Request:"
-          className={styles.anchor}
-        >
-          <img
-            className={classNames(styles.icon, rotateIcon && styles.rotateIcon)}
-            src={iconSrc}
-            alt={`${text} icon`}
-          />
-          {!isCollapsed && text}
-        </a>
-      </li>
-    );
-  }
-
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -87,11 +87,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
+              href="mailto:support@prolog-app.com?subject=Support Request: "
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              isActive={false}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
previous solution was bothering me the more I thought about it - it went against the reusable nature of React and shoehorned the desired behavior into the button component. I should have taken a cue from the name of the component that it was really just for rendering a button. 
